### PR TITLE
added `caldera_forms_mailer_nl2br` filter to prevent undesired `<br>` tags

### DIFF
--- a/classes/core.php
+++ b/classes/core.php
@@ -568,9 +568,11 @@ class Caldera_Forms {
 		// Filter Mailer first as not to have user input be filtered
 		$mail['message'] = self::do_magic_tags($mail['message']);
 
+		$nl2br = apply_filters( 'caldera_forms_mailer_nl2br', true );
+
 		if($form['mailer']['email_type'] == 'html'){
 			$mail['headers'][] = "Content-type: text/html";
-			$mail['message'] = nl2br($mail['message']);
+			$mail['message'] = $nl2br ? nl2br($mail['message']) : $mail['message'];
 		}
 
 		// get tags


### PR DESCRIPTION
I had some issues with the mailer feature using the visual editor to build the body of emails with tables, where the `nl2br()` function was adding a `<br>` tag for each table line. This pull request keeps the original behavior, but gives the user a way to remove this behavior if is outputting undesired tags.