### PR TITLE
More checks in conditional inside pf auto_populate_options_field

### DIFF
--- a/classes/core.php
+++ b/classes/core.php
@@ -1451,12 +1451,15 @@ class Caldera_Forms {
 			}
 		}
 
-		if(empty($field['config']['value_field']) || $field['config']['value_field'] == 'name' ){
-			foreach($field['config']['option'] as &$option){
-				$option['value'] = $option['label'];
+		if ( ( empty( $field['config']['value_field']) || $field[ 'config' ][ 'value_field' ] == 'name' ) && isset( $field[ 'config' ] ) && isset( $field[ 'config' ][ 'option' ] ) && is_array( $field[ 'config' ][ 'option' ] ) ){
+			foreach( $field[ 'config' ][ 'option' ] as &$option){
+				$option[ 'value' ] = $option[ 'label' ];
 			}
+
 		}
+
 		return $field;
+
 	}
 
 	static public function check_condition($conditions, $form, $entry_id=null){


### PR DESCRIPTION
This is designed to resolve: https://bitbucket.org/calderadev/caldera-easy-pods/issue/5/error-when-using-cep-as-search

I'm not sure what the original point of this conditional is and what regressions it could cause in CF itself.