### PR TITLE
make entry time comply with blog's timezone

### DIFF
--- a/classes/admin.php
+++ b/classes/admin.php
@@ -493,7 +493,7 @@ class Caldera_Forms_Admin {
 						}
 					}
 					$data['entries']['E' . $row->_entryid]['_entry_id'] = $row->_entryid;
-					$data['entries']['E' . $row->_entryid]['_date'] = date_i18n( $dateformat.' '.$timeformat, strtotime($row->_date_submitted), $gmt_offset);
+					$data['entries']['E' . $row->_entryid]['_date'] = date_i18n( $dateformat.' '.$timeformat, get_date_from_gmt( $row->_date_submitted, 'U'));
 
 					// setup default data array
 					if(!isset($data['entries']['E' . $row->_entryid]['data'])){

--- a/classes/core.php
+++ b/classes/core.php
@@ -1787,7 +1787,7 @@ class Caldera_Forms {
 							}
 							break;
 						case 'date':
-							$magic_tag = date($magic[1]);
+							$magic_tag = get_date_from_gmt(date('Y-m-d H:i:s'), $magic[1]);
 							break;
 						case 'user':
 							if(is_user_logged_in()){
@@ -3309,7 +3309,7 @@ class Caldera_Forms {
 		$timeformat = get_option( 'time_format' );
 		$gmt_offset = get_option( 'gmt_offset' );
 		$entry_detail = self::get_entry_detail($entry_id, $form);
-		$data['date'] = date_i18n( $dateformat.' '.$timeformat, strtotime($entry_detail['datestamp']), $gmt_offset);
+		$data['date'] = date_i18n( $dateformat.' '.$timeformat, get_date_from_gmt( $entry_detail['datestamp'], 'U'));
 
 		if(!empty($entry_detail['meta'])){
 			$data['meta'] = $entry_detail['meta'];


### PR DESCRIPTION
found an issue that all entries time displayed at admin backend is GMT and not in the time zone of Wordpress settings. It seems date_i18n function was not properly used (see here:https://wordpress.org/support/topic/date_i18n-and-timestamps), I changed the code to use wp's get_date_from_gmt( ). It should be more efficient than strtotime( ) as the time string format is limited to Y-m-d H:i:s. Also fix magic_tag {date} to get blog's time. All code tested and work fine on WP 4.1.1 and PHP 5.3, Hope this can help,thank u!