### PR TITLE
add options for autoclose and start view for datepicker

### DIFF
--- a/fields/date_picker/datepicker.php
+++ b/fields/date_picker/datepicker.php
@@ -11,7 +11,7 @@ if( !empty( $field['config']['language'] ) ){
 <?php echo $wrapper_before; ?>
 	<?php echo $field_label; ?>
 	<?php echo $field_before; ?>
-		<input <?php echo $field_placeholder; ?> type="text" data-provide="cfdatepicker" data-autoclose="true" data-field="<?php echo $field_base_id; ?>" class="<?php echo $field_class; ?>  is-cfdatepicker" id="<?php echo $field_id; ?>" <?php echo $has_lang; ?> data-date-format="<?php echo $field['config']['format']; ?>" name="<?php echo $field_name; ?>" value="<?php echo $field_value; ?>" <?php echo $field_required; ?>>
+		<input <?php echo $field_placeholder; ?> type="text" data-provide="cfdatepicker" data-field="<?php echo $field_base_id; ?>" class="<?php echo $field_class; ?>  is-cfdatepicker" id="<?php echo $field_id; ?>" <?php echo $has_lang; ?> data-date-format="<?php echo $field['config']['format']; ?>" data-date-start-view="<?php echo $field['config']['start-view']; ?>" data-date-autoclose="<?php echo $field['config']['autoclose']; ?>" name="<?php echo $field_name; ?>" value="<?php echo $field_value; ?>" <?php echo $field_required; ?>>
 		<?php echo $field_caption; ?>
 	<?php echo $field_after; ?>
 <?php echo $wrapper_after; ?>

--- a/fields/date_picker/setup.php
+++ b/fields/date_picker/setup.php
@@ -11,6 +11,24 @@
 	</div>
 </div>
 <div class="caldera-config-group">
+    <label><?php _e('Autoclose', 'caldera-forms'); ?></label>
+    <div class="caldera-config-field">
+        <label><input type="checkbox" class="field-config {{_id}}_autoclosed" name="{{_name}}[autoclose]" value="1" {{#if autoclose}}checked="checked"{{/if}}> <?php _e('Enable autoclose', 'caldera-forms'); ?></label>
+        <p class="description"><?php _e('If enabled, the date picker will automatically close after selecting the final input', 'caldera-forms'); ?></p>
+    </div>
+</div>
+<div class="caldera-config-group">
+    <label><?php _e('Start View', 'caldera-forms'); ?></label>
+    <div class="caldera-config-field">
+        <select class="block-input field-config" name="{{_name}}[start-view]">
+            <option value="month" {{#is start-view value="month"}}selected="selected"{{/is}}><?php _e('Month (Default)', 'caldera-forms'); ?></option>
+            <option value="year" {{#is start-view value="year"}}selected="selected"{{/is}}><?php _e('Year', 'caldera-forms'); ?></option>
+            <option value="decade" {{#is start-view value="decade"}}selected="selected"{{/is}}><?php _e('Decade', 'caldera-forms'); ?></option>
+        </select>
+        <p class="description"><?php _e('The starting view of the date picker (month, year, decade)', 'caldera-forms'); ?></p>
+    </div>
+</div>
+<div class="caldera-config-group">
 	<label><?php _e('language', 'caldera-forms'); ?></label>
 	<div class="caldera-config-field">
 		<select class="cfdatepicker-set-language block-input field-config" id="{{id}}" name="{{_name}}[language]" style="width: 90px;">


### PR DESCRIPTION
First pull request.

I made some changes to the plugin a while ago for my own personal needs and forgot to add a pull request. 

I added 2 options:
1. Checkbox for auto closing the datepicker. I noticed this just added a couple days ago, but not as an option.
2. Start view for the datepicker. I needed it to be 'decade' for a DOB input. 

Let me know if I made any mistakes. 
