### PR TITLE
"Disabled" option is back to Type in Conditions

### DIFF
--- a/ui/panels/conditions.php
+++ b/ui/panels/conditions.php
@@ -64,6 +64,7 @@ data-autoload="true"
 								<option value=""></option>
 								<option value="show" {{#is type value="show"}}selected="selected"{{/is}}><?php _e('Show', 'caldera-forms'); ?></option>
 								<option value="hide" {{#is type value="hide"}}selected="selected"{{/is}}><?php _e('Hide', 'caldera-forms'); ?></option>
+								<option value="disabled" {{#is type value="disabled"}}selected="selected"{{/is}}><?php _e('Disabled', 'caldera-forms'); ?></option>
 							</select>
 							{{#if type}}
 								<button type="button" data-add-group="{{id}}" class="pull-right button button-small"><?php echo __('Add Conditional Line', 'caldera-forms'); ?></button>


### PR DESCRIPTION
As in current stable version 1.3.0, the "Disabled" option is missing in the Type of Conditions. It is corrected now.