### PR TITLE
Use default WordPress collation for database tables.

### DIFF
--- a/classes/core.php
+++ b/classes/core.php
@@ -217,6 +217,16 @@ class Caldera_Forms {
 		
 		update_option('_calderaforms_lastupdate',CFCORE_VER);
 
+		$charset_collate = '';
+
+		if ( ! empty( $wpdb->charset ) ) {
+			$charset_collate = "DEFAULT CHARACTER SET $wpdb->charset";
+		}
+
+		if ( ! empty( $wpdb->collate ) ) {
+			$charset_collate .= " COLLATE $wpdb->collate";
+		}
+
 		$tables = $wpdb->get_results("SHOW TABLES", ARRAY_A);
 		foreach($tables as $table){
 			$alltables[] = implode($table);
@@ -236,8 +246,8 @@ class Caldera_Forms {
 			PRIMARY KEY (`meta_id`),
 			KEY `meta_key` (`meta_key`),
 			KEY `entry_id` (`entry_id`)
-			) DEFAULT CHARSET=utf8;";
-			
+			) " . $charset_collate . ";";
+
 			dbDelta( $meta_table );
 
 		}
@@ -257,7 +267,7 @@ class Caldera_Forms {
 			KEY `user_id` (`user_id`),
 			KEY `date_time` (`datestamp`),
 			KEY `status` (`status`)
-			) DEFAULT CHARSET=utf8;";
+			) " . $charset_collate . ";";
 
 			
 			dbDelta( $entry_table );
@@ -272,7 +282,7 @@ class Caldera_Forms {
 			KEY `form_id` (`entry_id`),
 			KEY `field_id` (`field_id`),
 			KEY `slug` (`slug`)
-			) DEFAULT CHARSET=utf8;";
+			) " . $charset_collate . ";";
 
 			dbDelta( $values_table );
 		


### PR DESCRIPTION
Hard-coding UTF8, particularly after WordPress Core's move to UTF8mb4 can cause issues in some database setups. This will allow the tables to use the default DB collation with a fallback to the default collation for the database itself without risk of introducing anything that could cause issues.