### PR TITLE
Swap link for 5 star review

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -31,7 +31,7 @@ A free plugin by <a href="https://CalderaWP.com" title="CalderaWP: Transform You
 > <em>Note:  We do not provide free support via WordPress.org. Premium add-on purchases include priority support for Caldera Forms.</em>
 
 
-Pippin Williamson of Easy Digital Downloads, Restrict Content Pro and AffiliateWP gives [Caldera Forms a 5 star rating](https://themesurgeons.com/wordpress-plugins-recommendations/)!
+Pippin Williamson of Easy Digital Downloads, Restrict Content Pro and AffiliateWP gives [Caldera Forms a 5 star rating](https://wordpress.org/support/topic/excellent-2257?replies=4)!
 
 John Teague of Theme Surgeons includes Caldera Forms in his list of [WordPress plugin recommendations I don’t get paid for](https://themesurgeons.com/wordpress-plugins-recommendations/).
 


### PR DESCRIPTION
Hyperlink was sending users to https://themesurgeons.com/wordpress-plugins-recommendations/ instead of the plugin repo review from Pippin.