### PR TITLE
Current dev

### DIFF
--- a/caldera-core.php
+++ b/caldera-core.php
@@ -4,7 +4,7 @@
   Plugin URI: https://calderawp.com/caldera-forms/
   Description: Easy to use, grid based responsive form builder for creating simple to complex forms.
   Author: David Cramer
-  Version: 1.3.3.1
+  Version: 1.3.4-b1
   Author URI: https://calderawp.com
   Text Domain: caldera-forms
   GitHub Plugin URI: https://github.com/Desertsnowman/Caldera-Forms/
@@ -20,7 +20,7 @@ if ( ! defined( 'WPINC' ) ) {
 
 define('CFCORE_PATH', plugin_dir_path(__FILE__));
 define('CFCORE_URL', plugin_dir_url(__FILE__));
-define('CFCORE_VER', '1.3.3.1');
+define('CFCORE_VER', '1.3.4-b1');
 define('CFCORE_EXTEND_URL', 'https://api.calderaforms.com/1.0/');
 
 include_once CFCORE_PATH . 'classes/core.php';

--- a/classes/admin.php
+++ b/classes/admin.php
@@ -1431,7 +1431,9 @@ class Caldera_Forms_Admin {
 						if( is_array( $row[$key] ) && isset( $row[$key]['label'] ) ){
 							$row[$key] = $row[$key]['value'];
 						}elseif( is_array( $row[$key] ) && count( $row[$key] ) === 1 ){
-							$row[$key] = $row[$key][0];
+                            reset($row[$key]);
+                            $sub_arr_key = key($row[$key]);
+                            $row[$key] = $row[$key][$sub_arr_key];
 						}elseif( is_array( $row[$key] ) ){
 							$subs = array();
 							foreach( $row[$key] as $row_part ){

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: Desertsnowman, Shelob9
 Tags: forms, formbuilder, form builder, contact form, contact, custom form, custom forms, forms creator, caldera forms, calderawp, wp form, responsive, forms, form, drag and drop, email, awesome, wordpress free form builder, form builder plugin wordpress, wordpress builder plugin, wordpress forms builder, form builder wordpress, contact form builder wordpress, bootstrap, bootstrap form builder, bootstrap forms, login forms, drag and drop forms, responsive forms, mailchimp, mailchimp form, credit card form, braintree, braintree form, authorize.net, authorize.net form, dwolla, dwolla form, paypal, paypal form, hi roy, search forms, pods, advanced custom fields, easy forms, contact form builder, contact, email, auto-responder,
 Requires at least: 4.3
 Tested up to: 4.5
-Stable tag: 1.3.3.1
+Stable tag: 1.3.4-b1
 License: GPLv2
 
 A diffrent kind of WordPress form builder.


### PR DESCRIPTION
CSV export of entries has blank fields for checkboxes when only one is ticked.

In the file classes/admin.php

Line 1434
$row[$key] = $row[$key][0];

Will not work for some checkboxes (when only one value is ticked) because in that case $row[$key][0] is an associative array not a numerical one.

So, to work in all cases, I replaced Line 1434 with the following

reset($row[$key]);
$sub_arr_key = key($row[$key]);
$row[$key] = $row[$key][$sub_arr_key];