### PR TITLE
export of entries to CSV  - missing values with checkboxes bug

### DIFF
--- a/classes/admin.php
+++ b/classes/admin.php
@@ -1431,8 +1431,8 @@ class Caldera_Forms_Admin {
 						if( is_array( $row[$key] ) && isset( $row[$key]['label'] ) ){
 							$row[$key] = $row[$key]['value'];
 						}elseif( is_array( $row[$key] ) && count( $row[$key] ) === 1 ){
-                            reset($row[$key]);
-                            $sub_arr_key = key($row[$key]);
+                            reset( $row[$key] );
+                            $sub_arr_key = key( $row[$key] );
                             $row[$key] = $row[$key][$sub_arr_key];
 						}elseif( is_array( $row[$key] ) ){
 							$subs = array();

--- a/classes/admin.php
+++ b/classes/admin.php
@@ -1431,7 +1431,9 @@ class Caldera_Forms_Admin {
 						if( is_array( $row[$key] ) && isset( $row[$key]['label'] ) ){
 							$row[$key] = $row[$key]['value'];
 						}elseif( is_array( $row[$key] ) && count( $row[$key] ) === 1 ){
-							$row[$key] = $row[$key][0];
+                            reset($row[$key]);
+                            $sub_arr_key = key($row[$key]);
+                            $row[$key] = $row[$key][$sub_arr_key];
 						}elseif( is_array( $row[$key] ) ){
 							$subs = array();
 							foreach( $row[$key] as $row_part ){


### PR DESCRIPTION
CSV export of entries has blank fields for checkboxes when only one is ticked.

In the file classes/admin.php

Line 1434
$row[$key] = $row[$key][0];

Will not work for some checkboxes (when only one value is ticked) because in that case $row[$key][0] is an associative array not a numerical one.

So, to work in all cases, I replaced Line 1434 with the following

reset($row[$key]);
$sub_arr_key = key($row[$key]);
$row[$key] = $row[$key][$sub_arr_key];